### PR TITLE
Update CI to use 22.04 where 20.04 was used

### DIFF
--- a/.github/workflows/clang_format_check.yaml
+++ b/.github/workflows/clang_format_check.yaml
@@ -1,15 +1,22 @@
 name: clang-format-check
-on:
-    push:
+on: [pull_request, push]
 
 jobs:
   build:
     name: clang-format-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    # Run on external PRs, but not internal PRs as they'll be run by the push
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
     steps:
         - name: Fetch repository
-          uses: actions/checkout@v1
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
         - name: Install packages
-          run: sudo apt-get install python3-venv
+          run: sudo apt-get update && sudo apt-get install python3-venv
+
         - name: check_clang_format
-          run: ci/check_clang_format.sh
+          run: |
+            ci/check_clang_format.sh

--- a/.github/workflows/coverage_test.yaml
+++ b/.github/workflows/coverage_test.yaml
@@ -5,18 +5,20 @@ on:
 jobs:
     build:
         name: coverage-test
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@v2
             - name: Fetch repository
-              run: git fetch --prune --unshallow
-            - name: Get submodules
-              run: git submodule update --init --force --recursive
+              uses: actions/checkout@v4
+              with:
+                fetch-depth: 1
+                submodules: recursive
+
             - name: Install packages
               run: sudo apt-get install build-essential libhdf5-dev hdf5-tools lcov
+
             - name: Build and run unittests
               run: ci/coverage_test.sh
+
             - name: Upload Coverage to Coveralls
               uses: coverallsapp/github-action@master
               with:

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -16,7 +16,7 @@ jobs:
             - name: Fetch repository
               uses: actions/checkout@v4
               with:
-                fetch-depth: 0
+                fetch-depth: 1
                 submodules: recursive
 
             - name: Install parallel packages

--- a/.github/workflows/run_test.yaml
+++ b/.github/workflows/run_test.yaml
@@ -8,23 +8,25 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ ubuntu-20.04 ]
+                os: [ ubuntu-22.04 ]
                 config:
                   - {cmake_option: "-DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_CONVERTER=ON", mpi: ON}
                   - {cmake_option: "-DSONATA_REPORT_ENABLE_SUBMODULES=ON -DSONATA_REPORT_ENABLE_MPI=OFF -DSONATA_REPORT_ENABLE_CONVERTER=ON", mpi: OFF}
         steps:
-            - name: Checkout repository
-              uses: actions/checkout@v2
             - name: Fetch repository
-              run: git fetch --prune --unshallow
-            - name: Get submodules
-              run: git submodule update --init --force --recursive
+              uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+                submodules: recursive
+
             - name: Install parallel packages
               if: ${{ matrix.config.mpi == 'ON' }}
               run: sudo apt-get install mpich libmpich-dev libhdf5-mpich-dev hdf5-tools
+
             - name: Install serial packages
               if: ${{ matrix.config.mpi == 'OFF' }}
               run: sudo apt-get install libhdf5-dev hdf5-tools
+
             - name: Build and run tests
               run: mkdir BUILD && cd BUILD && cmake ${cmake_option} .. && make all && ctest --output-on-failure
               env:


### PR DESCRIPTION
* 20.04 has been deprecated: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/
* update actions dependencies where applicable